### PR TITLE
Keep activities when using multiCount=true

### DIFF
--- a/web/includes/css/spaceassess.css
+++ b/web/includes/css/spaceassess.css
@@ -43,7 +43,7 @@ html {
 
 input#goesup {
     width: 90%;
-    height: 320px;
+    height: 320px; 
     font-size: 5em;
 }
 
@@ -208,6 +208,7 @@ li.loc_item a {
     margin-bottom: 4px;
     margin-left: 5px;
 }
+
 /* UMICH CHANGE */
 .activityContainer {
     /* max-width: 210px; */
@@ -235,6 +236,7 @@ li.loc_item a {
 .retroMode {
     display: none;
 }
+
 
 /* UMICH CHANGES */
 
@@ -313,11 +315,9 @@ p.umichInstructions {
 
 @media all and (max-width: 480px) {
 /* Rules to begin supporting smaller devices */
-    form#count_form input#goesup {
-      -webkit-appearance: none;
-      -moz-appearance:    none;
-      appearance:         none;
-      font-size: 1em;
+    input#goesup {
+        height: 120px;
+        font-size: 3em;
     }
 
     select#init_selector {

--- a/web/includes/js/spaceassess.js
+++ b/web/includes/js/spaceassess.js
@@ -632,9 +632,22 @@ function countPeople(doubleTap) {
         }
 
         var countObj = new Person({timestamp:date.getTime()});
-        $("input.check:checked", countForm).each(function() {
-            countObj.activities.add(currentActivities[$(this).val()]);
-        }).prop("checked", false).button("refresh");
+        // UMICH CHANGE 16FEB2018 - Leave activities checked
+        // until location changes if multiCount is true
+        if (getQueryVariable('multiCount') === 'true') {
+          // $("input.check:checked", countForm).each(function() {
+          //     countObj.activities.add(currentActivities[$(this).val()]);
+          // }).prop("checked", false).button("refresh");
+          $("input.check:checked", countForm).each(function() {
+              countObj.activities.add(currentActivities[$(this).val()]);
+          });
+        } else {
+          $("input.check:checked", countForm).each(function() {
+              countObj.activities.add(currentActivities[$(this).val()]);
+          }).prop("checked", false).button("refresh");
+        }
+        // UMICH CHANGE END 16FEB2018
+
         countObj.location = currentLoc;
         countObj.session = currentSession;
         countObj.count = newCount;
@@ -793,6 +806,15 @@ $(function() {
     $("div#loc_lists").on("click", "li.loc_item a", function() {
         currentLoc = null;
         currentLocCount = null;
+        
+        // UMICH CHANGE 16FEB2018 
+        if (getQueryVariable('multiCount') === 'true') {
+          $("input.check:checked", countForm).each(function() {
+            // Just clear the checked activity items
+          }).prop("checked", false).button("refresh");
+        }
+        // END UMICH CHANGE 16FEB2018
+        
         $("#loadingScreen").dialog('open');
         var currentList = $(this).parent().parent();
         clickEl = this;


### PR DESCRIPTION
If the url option multiCount=true is on:
1. Don't reset activity buttons when a count is added.
2. Reset activity buttons when the location is changed.

If the url option multiCount is not true then:
1. Reset activity buttons after each count is added.